### PR TITLE
Fix bug causing screenshot not being downloaded on 2.4.0

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Screenshot YouTube",
-	"version": "2.4.0",
+	"version": "2.4.1",
 
 	"description": "Take a screenshot of any YouTube video with one click.",
 	"icons": {

--- a/extension/page.js
+++ b/extension/page.js
@@ -83,7 +83,7 @@ function CaptureScreenshot() {
 	// Create and download image in the selected format if needed
 	if (screenshotFunctionality == 0 || (screenshotFunctionality == 2 && screenshotFormat !== 'png')) {
 		canvas.toBlob(async function (blob) {
-			downloadBlob(blob);
+			DownloadBlob(blob);
 		}, 'image/' + screenshotFormat);
 	}
 }


### PR DESCRIPTION
Fix function naming which causes
`Uncaught (in promise) ReferenceError: downloadBlob is not defined`