### PR TITLE
Update Manifest V3

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,5 +1,0 @@
-chrome.webNavigation.onHistoryStateUpdated.addListener(function(data) {
-	chrome.tabs.get(data.tabId, function(tab) {
-		chrome.tabs.executeScript(data.tabId, {code: 'if (typeof AddScreenshotButton !== "undefined") { AddScreenshotButton(); }', runAt: 'document_start'});
-	});
-}, {url: [{hostSuffix: '.youtube.com'}]});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,10 +12,6 @@
 
 	"options_page": "options.html",
 
-	"background": {
-		"service_worker": "background.js"
-	},
-
 	"content_scripts": [
 		{
 			"matches": ["https://www.youtube.com/*"],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "Screenshot YouTube",
 	"version": "2.4.1",
 
@@ -13,9 +13,9 @@
 	"options_page": "options.html",
 
 	"background": {
-		"scripts": ["background.js"]
+		"service_worker": "background.js"
 	},
-	
+
 	"content_scripts": [
 		{
 			"matches": ["https://www.youtube.com/*"],
@@ -26,8 +26,12 @@
 	],
 
 	"permissions": [
-		"https://www.youtube.com/*",
 		"webNavigation",
 		"storage"
+	],
+
+	"host_permissions": [
+		"https://www.youtube.com/*"
 	]
+
 }


### PR DESCRIPTION
Resolve #21
Update to V3, due to the end of support for Manifest V2 extensions.

Ref: https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline

Also, remove `background.js` as it will no longer function with the migration of background scripts to Service Worker.
I have confirmed that this change does not interfere with the operation in my environment.

Ref: https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep-sw-alive

---
This text has been translated from Japanese into English by DeepL. Thanks!